### PR TITLE
Add workaround for leading / on Windows paths

### DIFF
--- a/src/svelte.rs
+++ b/src/svelte.rs
@@ -70,8 +70,7 @@ impl zed::Extension for SvelteExtension {
         Ok(zed::Command {
             command: zed::node_binary_path()?,
             args: vec![
-                env::current_dir()
-                    .unwrap()
+                zed_ext::sanitize_windows_path(env::current_dir().unwrap())
                     .join(&server_path)
                     .to_string_lossy()
                     .to_string(),
@@ -122,3 +121,24 @@ impl zed::Extension for SvelteExtension {
 }
 
 zed::register_extension!(SvelteExtension);
+/// Extensions to the Zed extension API that have not yet stabilized.
+mod zed_ext {
+    /// Sanitizes the given path to remove the leading `/` on Windows.
+    ///
+    /// On macOS and Linux this is a no-op.
+    ///
+    /// This is a workaround for https://github.com/bytecodealliance/wasmtime/issues/10415.
+    pub fn sanitize_windows_path(path: std::path::PathBuf) -> std::path::PathBuf {
+        use zed_extension_api::{current_platform, Os};
+
+        let (os, _arch) = current_platform();
+        match os {
+            Os::Mac | Os::Linux => path,
+            Os::Windows => path
+                .to_string_lossy()
+                .to_string()
+                .trim_start_matches('/')
+                .into(),
+        }
+    }
+}

--- a/src/svelte.rs
+++ b/src/svelte.rs
@@ -121,6 +121,7 @@ impl zed::Extension for SvelteExtension {
 }
 
 zed::register_extension!(SvelteExtension);
+
 /// Extensions to the Zed extension API that have not yet stabilized.
 mod zed_ext {
     /// Sanitizes the given path to remove the leading `/` on Windows.


### PR DESCRIPTION
This is based on https://github.com/zed-extensions/astro/pull/5 which addresses https://github.com/zed-industries/zed/issues/20559 so that svelte users on windows can also use the extension.

Credits to @maxdeviant  for the original astro fix