### PR TITLE
Improve tag auto-indent

### DIFF
--- a/languages/svelte/brackets.scm
+++ b/languages/svelte/brackets.scm
@@ -5,3 +5,5 @@
 ("(" @open ")" @close)
 ; ("[" @open "]" @close)
 ; ("`" @open "`" @close)
+
+((element (start_tag) @open [(end_tag) (erroneous_end_tag)] @close) (#set! newline.only))

--- a/languages/svelte/indents.scm
+++ b/languages/svelte/indents.scm
@@ -10,5 +10,5 @@
   (self_closing_tag "/>" @end)
   (element
     (start_tag) @start
-    (end_tag)? @end)
+    [(end_tag) (erroneous_end_tag)]? @end)
 ] @indent


### PR DESCRIPTION
Improves auto-indent and newline.only queries. This makes it so when hitting enter between an open and closing tag like so
```html
<div>|</div>
```
The result is:
```html
<div>
    |
</div>
```
Instead of:
```html
<div>
|</div>
```

Even when the closing tag does not have the same name as the opening tag (i.e. `<div></p>` still auto-indents correctly)
