### PR TITLE
Improve completions

### DIFF
--- a/src/svelte.rs
+++ b/src/svelte.rs
@@ -112,6 +112,7 @@ impl zed::Extension for SvelteExtension {
 
         Ok(Some(serde_json::json!({
             "provideFormatter": true,
+            "dontFilterIncompleteCompletions": true,
             "configuration": {
                 "typescript": config,
                 "javascript": config


### PR DESCRIPTION
Completions are now not pre-filtered by the server. This change is most notable in style blocks, because emmet now works as expected. Inputting `db` will correctly suggest `display: block`.

As a workaround the following setting can be added:
```
	"lsp": {
		"svelte-language-server": {
			"initialization_options": {
				"dontFilterIncompleteCompletions": true
			}
		}
	},
```