### PR TITLE
fix for issue 20: Wrong indentation of script or style elements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "zed_svelte"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "zed_extension_api",
 ]

--- a/languages/svelte/indents.scm
+++ b/languages/svelte/indents.scm
@@ -4,8 +4,6 @@
   (each_statement)
   (await_statement)
   (snippet_statement)
-  (script_element)
-  (style_element)
   (start_tag ">" @end)
   (self_closing_tag "/>" @end)
   (element


### PR DESCRIPTION
I just deleted two lines from indents.scm which seemed to be causing the indentation to not work properly. I'm not sure if this affects anything else but it was a quick fix. 