### PR TITLE
Update `Cargo.lock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "zed_svelte"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "zed_extension_api",
 ]


### PR DESCRIPTION
Updates the lockfile to be in line with the extension version. Follows up https://github.com/zed-extensions/svelte/pull/32