### PR TITLE
Improve auto indents for style and script elements

### DIFF
--- a/languages/svelte/indents.scm
+++ b/languages/svelte/indents.scm
@@ -11,4 +11,10 @@
   (element
     (start_tag) @start
     [(end_tag) (erroneous_end_tag)]? @end)
+  (script_element
+    (start_tag) @start
+    [(end_tag) (erroneous_end_tag)]? @end)
+  (style_element
+    (start_tag) @start
+    [(end_tag) (erroneous_end_tag)]? @end)
 ] @indent


### PR DESCRIPTION
Closes https://github.com/zed-extensions/svelte/issues/20
Closes https://github.com/zed-extensions/svelte/pull/33

This PR fixes the issue where style and script indents would be incorrect once either of the tags was opened.

Before:

https://github.com/user-attachments/assets/6469a17b-0c32-410f-9c99-74b2661cb3d5

After:

https://github.com/user-attachments/assets/aa0669f3-f2aa-4c09-898b-db2a5fb2f550

