### PR TITLE
Bump extension API, remove windows path workaround

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "zed_extension_api"
-version = "0.4.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc7f7867316e62864b4f0953e3ce1d05501ba7278cca4e5e5a9694d9182f5c7"
+checksum = "0729d50b4ca0a7e28e590bbe32e3ca0194d97ef654961451a424c661a366fca0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ path = "src/svelte.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.4.0"
+zed_extension_api = "0.7.0"

--- a/src/svelte.rs
+++ b/src/svelte.rs
@@ -69,7 +69,8 @@ impl zed::Extension for SvelteExtension {
         Ok(zed::Command {
             command: zed::node_binary_path()?,
             args: vec![
-                zed_ext::sanitize_windows_path(env::current_dir().unwrap())
+                env::current_dir()
+                    .unwrap()
                     .join("node_modules")
                     .join(PACKAGE_NAME)
                     .join("bin/server.js")
@@ -133,7 +134,7 @@ impl zed::Extension for SvelteExtension {
                     "tsserver": {
                         "globalPlugins": [{
                             "name": TS_PLUGIN_PACKAGE_NAME,
-                            "location": zed_ext::sanitize_windows_path(env::current_dir().unwrap())
+                            "location": env::current_dir().unwrap()
                                 .join("node_modules")
                                 .join(&TS_PLUGIN_PACKAGE_NAME)
                                 .to_string_lossy()
@@ -149,25 +150,3 @@ impl zed::Extension for SvelteExtension {
 }
 
 zed::register_extension!(SvelteExtension);
-
-/// Extensions to the Zed extension API that have not yet stabilized.
-mod zed_ext {
-    /// Sanitizes the given path to remove the leading `/` on Windows.
-    ///
-    /// On macOS and Linux this is a no-op.
-    ///
-    /// This is a workaround for https://github.com/bytecodealliance/wasmtime/issues/10415.
-    pub fn sanitize_windows_path(path: std::path::PathBuf) -> std::path::PathBuf {
-        use zed_extension_api::{current_platform, Os};
-
-        let (os, _arch) = current_platform();
-        match os {
-            Os::Mac | Os::Linux => path,
-            Os::Windows => path
-                .to_string_lossy()
-                .to_string()
-                .trim_start_matches('/')
-                .into(),
-        }
-    }
-}


### PR DESCRIPTION
⚠️ Don't merge until Zed 0.205.x is on stable ⚠️ 

See https://github.com/zed-industries/zed/pull/37811

This PR bumps the zed extension API to the latest version, which removes the need to work around a bug where `current_dir()` returned an invalid path on windows.