### PR TITLE
Add Svelte MCP support

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -13,3 +13,6 @@ language = "Svelte"
 [grammars.svelte]
 repository = "https://github.com/tree-sitter-grammars/tree-sitter-svelte"
 commit = "3f06f705410683adb17d146b5eca28c62fe81ba6"
+
+[context_servers.svelte]
+name = "Svelte MCP"


### PR DESCRIPTION
Svelte now has [an official MCP server](https://svelte.dev/docs/mcp/overview), and with Zed providing the ability to configure these in extensions it feels like the perfect opportunity to add this to the official extension