### PR TITLE
Add `wrap_characters` for `wrap selections in tag` action

### DIFF
--- a/languages/svelte/config.toml
+++ b/languages/svelte/config.toml
@@ -2,6 +2,7 @@ name = "Svelte"
 grammar = "svelte"
 path_suffixes = ["svelte"]
 block_comment = ["<!-- ", " -->"]
+wrap_characters = { start_prefix = "<", start_suffix = ">", end_prefix = "</", end_suffix = ">" }
 autoclose_before = ":\"'}]>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },


### PR DESCRIPTION
this pr adds support for the wrap selection in tag action

<img width="1516" height="1236" alt="image" src="https://github.com/user-attachments/assets/156e020a-9547-49c8-8adb-d9f53f2dc35b" />
