### PR TITLE
fix: install typescript for the language server

### DIFF
--- a/src/svelte.rs
+++ b/src/svelte.rs
@@ -75,7 +75,7 @@ impl zed::Extension for SvelteExtension {
         self.install_package_if_needed(id, PACKAGE_NAME)?;
         self.install_package_if_needed(id, TS_PLUGIN_PACKAGE_NAME)?;
 
-        // Peer dependencies of svelte-language-server. Ensure TypeScript is installed as well
+        // Peer dependencies of svelte-language-server. Ensure TypeScript is installed and updated as well
         self.install_package_if_needed(id, TYPESCRIPT_PACKAGE_NAME)?;
 
         let path = get_package_path(PACKAGE_NAME)?

--- a/src/svelte.rs
+++ b/src/svelte.rs
@@ -6,6 +6,7 @@ struct SvelteExtension {
 }
 
 const PACKAGE_NAME: &str = "svelte-language-server";
+const TYPESCRIPT_PACKAGE_NAME: &str = "typescript";
 const TS_PLUGIN_PACKAGE_NAME: &str = "typescript-svelte-plugin";
 
 fn get_package_path(package_name: &str) -> Result<PathBuf> {
@@ -73,6 +74,9 @@ impl zed::Extension for SvelteExtension {
     ) -> Result<zed::Command> {
         self.install_package_if_needed(id, PACKAGE_NAME)?;
         self.install_package_if_needed(id, TS_PLUGIN_PACKAGE_NAME)?;
+
+        // Peer dependencies of svelte-language-server. Ensure TypeScript is installed as well
+        self.install_package_if_needed(id, TYPESCRIPT_PACKAGE_NAME)?;
 
         let path = get_package_path(PACKAGE_NAME)?
             .join("bin/server.js")

--- a/src/svelte.rs
+++ b/src/svelte.rs
@@ -74,8 +74,7 @@ impl zed::Extension for SvelteExtension {
     ) -> Result<zed::Command> {
         self.install_package_if_needed(id, PACKAGE_NAME)?;
         self.install_package_if_needed(id, TS_PLUGIN_PACKAGE_NAME)?;
-
-        // Peer dependencies of svelte-language-server. Ensure TypeScript is installed and updated as well
+        // Peer dependency of svelte-language-server. Ensures TypeScript is installed and up to date
         self.install_package_if_needed(id, TYPESCRIPT_PACKAGE_NAME)?;
 
         let path = get_package_path(PACKAGE_NAME)?


### PR DESCRIPTION
Svelte language server plans to move TypeScript to peerDependency as part of TypeScript 6 support. The reason is to allow people to continue using TypeScript 5 if needed. ~~This means npm won't automatically install TypeScript anymore, so the extension needs to install it manually.~~ But it's still beneficial to have this to ensure TypeScript is updated.