### PR TITLE
Improve error handling during package installation

### DIFF
--- a/src/svelte.rs
+++ b/src/svelte.rs
@@ -52,7 +52,10 @@ impl SvelteExtension {
                     eprintln!("Warning: failed to installed the most recent {package_name} package: {error}");
 
                     if installed_version.is_none() {
-                        return Err(format!("Error: failed to install {package_name}@{latest_version}: {}", error));
+                        return Err(format!(
+                            "Error: failed to install {package_name}@{latest_version}: {}",
+                            error
+                        ));
                     } else {
                         eprintln!("Utilizing already installed fallback package")
                     }

--- a/src/svelte.rs
+++ b/src/svelte.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, env, path::PathBuf};
+use std::{collections::HashSet, env, fs, path::PathBuf};
 use zed_extension_api::{self as zed, serde_json, Result};
 
 struct SvelteExtension {
@@ -44,14 +44,30 @@ impl SvelteExtension {
                 &zed::LanguageServerInstallationStatus::Downloading,
             );
 
-            if let Err(error) = zed::npm_install_package(package_name, &latest_version) {
-                // If installation failed, but we don't want to error but rather reuse existing version
-                if installed_version.is_none() {
-                    Err(error)?;
+            match zed::npm_install_package(package_name, &latest_version) {
+                Ok(_) => {
+                    println!("{package_name} installed with success!")
+                }
+                Err(error) => {
+                    eprintln!("Warning: failed to installed the most recent {package_name} package: {error}");
+
+                    if installed_version.is_none() {
+                        return Err(format!("Error: failed to install {package_name}@{latest_version}: {}", error));
+                    } else {
+                        eprintln!("Utilizing already installed fallback package")
+                    }
                 }
             }
         } else {
             println!("Found {package_name}@{latest_version} installed");
+        }
+
+        let package_path = get_package_path(package_name)?;
+        if fs::metadata(&package_path).is_err() {
+            return Err(format!(
+                "Integrity fail: {package_name}@{latest_version} not found at {}",
+                package_path.display()
+            ));
         }
 
         self.installed.insert(package_name.into());


### PR DESCRIPTION
## Description

This PR enhances the `install_package_if_needed` logic in `src/svelte.rs` to make the LSP installation process more robust and resilient to network or permission failures. 

Previously, the installation logic was overly optimistic, potentially failing silently and leading to downstream crashes when trying to spawn the language server from a non-existent or corrupted directory.

## Changes

* **Explicit Error Reporting:** Replaced the silent failure approach with an explicit `match` statement on `zed::npm_install_package`. If the installation fails and no cached version is available, it now returns a descriptive critical error.
* **Integrity/Sanity Check:** Added a post-installation check using `fs::metadata` to verify that the `package_path` directory actually exists on disk before marking the package as successfully installed.