### PR TITLE
Exclude markup punctuation from rainbow brackets

### DIFF
--- a/languages/svelte/brackets.scm
+++ b/languages/svelte/brackets.scm
@@ -1,9 +1,9 @@
-("<" @open ">" @close)
+(("<" @open ">" @close) (#set! rainbow.exclude))
 ("{" @open "}" @close)
-("'" @open "'" @close)
-("\"" @open "\"" @close)
+(("'" @open "'" @close) (#set! rainbow.exclude))
+(("\"" @open "\"" @close) (#set! rainbow.exclude))
 ("(" @open ")" @close)
 ; ("[" @open "]" @close)
 ; ("`" @open "`" @close)
 
-((element (start_tag) @open [(end_tag) (erroneous_end_tag)] @close) (#set! newline.only))
+((element (start_tag) @open [(end_tag) (erroneous_end_tag)] @close) (#set! newline.only) (#set! rainbow.exclude))


### PR DESCRIPTION
## Problem

With `"colorize_brackets": true` (rainbow brackets), Zed colors every pair declared in `brackets.scm` from the theme's `accents` array, by nesting depth. That overrides the theme's syntax colors for those tokens.

In Svelte files this hits the markup punctuation:

- `<` and `>` are painted from `accents` instead of the theme's `tag.punctuation.bracket`
- attribute quotes are painted from `accents` instead of the theme's `string`, so `class="foo"` shows gold delimiters around a differently-colored body

It also renders *inconsistently*, which is what makes it look like a bug rather than a preference. `("<" @open ">" @close)` matches `<` and `>` only as siblings, and that only happens in a start tag — an end tag is `</` … `>` (no `<` token) and a self-closing tag is `<` … `/>` (no `>` token). So `<div …>` is rainbow-colored while the `</div>` closing it keeps the theme color.

## Fix

Mark those pairs `rainbow.exclude`, which is what the bundled HTML extension already does for its tag punctuation and quotes:

`{}` and `()` are left rainbow-colored — mustache blocks and expressions are where the feature actually earns its keep in Svelte markup. Bracket *matching* and the `newline.only` indent behavior are unchanged; `rainbow.exclude` only opts the pair out of colorization.

## Testing

Applied to the installed extension copy on Zed 1.15 (Windows) with `colorize_brackets: true`. Angle brackets and attribute quotes now follow the theme, start and end tags match each other, and `{}` / `()` still cycle through the accent colors.
